### PR TITLE
chore: upgrade dependencies from milestone to stable GA releases

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.0-M3</version>
+		<version>4.0.5</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.massivemarketmanager</groupId>
@@ -28,7 +28,7 @@
 	</scm>
 	<properties>
 		<java.version>25</java.version>
-		<lombok.version>1.18.42</lombok.version>
+		<lombok.version>1.18.44</lombok.version>
         <mapstruct.version>1.6.3</mapstruct.version>
 	</properties>
 	<dependencies>
@@ -109,7 +109,7 @@
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-			<version>3.0.0-M1</version>
+			<version>3.0.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -119,7 +119,7 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-vault-config</artifactId>
-			<version>5.0.0-M3</version>
+			<version>5.0.1</version>
 		</dependency>
         <!-- https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-api -->
         <dependency>
@@ -152,7 +152,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-                <version>3.14.1</version>
+                <version>3.15.0</version>
 				<configuration>
                     <source>25</source>
                     <target>25</target>
@@ -171,7 +171,7 @@
                         <path>
                             <groupId>org.springframework.boot</groupId>
                             <artifactId>spring-boot-configuration-processor</artifactId>
-                            <version>4.0.0-M3</version>
+                            <version>4.0.5</version>
                         </path>
 					</annotationProcessorPaths>
                     <compilerArgs>


### PR DESCRIPTION
Migrate all pre-release/milestone dependencies to latest stable versions:
- Spring Boot 4.0.0-M3 → 4.0.5
- Lombok 1.18.42 → 1.18.44
- springdoc-openapi 3.0.0-M1 → 3.0.2
- Spring Cloud Vault 5.0.0-M3 → 5.0.1
- maven-compiler-plugin 3.14.1 → 3.15.0