### PR TITLE
feat: wire up frontend auth flow end-to-end with backend

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:9000

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,6 +10,7 @@ import DashboardSettings from "@/components/dashboard/settings/dashboard-setting
 import LandingPage from "./pages/LandingPage.jsx"
 import Auth from "./pages/Auth.jsx"
 import NotFoundPage from "./pages/NotFoundPage.jsx"
+import ProtectedRoute from "@/components/ProtectedRoute.jsx"
 
 
 function App() {
@@ -23,7 +24,14 @@ function App() {
           <Route path='check-email' element={<CheckEmailForm />} />
           <Route path='verify' element={<VerifyEmailForm />} />
         </Route>
-        <Route path="/dashboard" element={<Dashboard />} >
+        <Route
+          path="/dashboard"
+          element={
+            <ProtectedRoute>
+              <Dashboard />
+            </ProtectedRoute>
+          }
+        >
           <Route index element={<Navigate to="overview" replace />} />
           <Route path="overview" element={<DashboardOverview />} />
           <Route path="analytics" element={<></>} />

--- a/frontend/src/components/ProtectedRoute.jsx
+++ b/frontend/src/components/ProtectedRoute.jsx
@@ -1,0 +1,22 @@
+import { Navigate, useLocation } from "react-router-dom"
+import { Loader2Icon } from "lucide-react"
+import { useAuth } from "@/context/AuthContext"
+
+export default function ProtectedRoute({ children }) {
+  const { isAuthenticated, loading } = useAuth()
+  const location = useLocation()
+
+  if (loading) {
+    return (
+      <div className="flex h-screen w-full items-center justify-center">
+        <Loader2Icon className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate to="/auth/sign-in" replace state={{ from: location }} />
+  }
+
+  return children
+}

--- a/frontend/src/components/auth/CheckEmailForm.jsx
+++ b/frontend/src/components/auth/CheckEmailForm.jsx
@@ -9,6 +9,7 @@ import { Toaster } from "@/components/ui/sonner"
 import { CheckCircle2, XCircle } from "lucide-react"
 
 import { toast } from "sonner"
+import { apiClient } from "@/lib/apiClient"
 
 export default function CheckEmailForm() {
   const { search } = useLocation()
@@ -19,19 +20,11 @@ export default function CheckEmailForm() {
   
 
   const resend = async () => {
-    //setMsg(null)
     setLoading(true)
     try {
-      const res = await fetch('http://localhost:8080/api/auth/resend-verification', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email }),
-      })
-      if (!res.ok) throw new Error(`HTTP ${res.status}`)
-      //setMsg({ ok: true, text: 'Verification email sent again' })
+      await apiClient.post('/api/auth/resend-verification', { email }, { auth: false })
       makeToast("Verification email sent again", "success")
     } catch (e) {
-      //setMsg({ ok: false, text: e.message || 'Failed to resend' })
       makeToast(e.message || "Failed to resend", "error")
     } finally {
       setLoading(false)

--- a/frontend/src/components/auth/SignUpForm.jsx
+++ b/frontend/src/components/auth/SignUpForm.jsx
@@ -16,6 +16,7 @@ import { toast } from "sonner"
 import { Toaster } from "@/components/ui/sonner"
 
 import { useNavigate } from "react-router-dom"
+import { apiClient } from "@/lib/apiClient"
 
 export default function SignUpForm() {
   const [email, setEmail] = useState("")
@@ -62,36 +63,12 @@ export default function SignUpForm() {
 
     setLoading(true);
     try {
-      const res = await fetch("http://localhost:8080/api/auth/sign-up", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          email: emailNorm,
-          password: password1,
-        }),
-      });
-
-      const isJson = res.headers.get("content-type")?.includes("application/json");
-      const payload = isJson ? await res.json() : await res.text();
-
-      if (!res.ok) {
-        console.log("Error payload:", payload);
-        let msg = typeof payload === "string" ? payload : "";
-        if (!msg && payload && typeof payload === "object") {
-          if (payload.detail) msg = payload.detail;
-          else if (payload.message) msg = payload.message;
-          else if (Array.isArray(payload.errors) && payload.errors.length) {
-            msg = payload.errors
-              .map(e => e.defaultMessage || e.message || `${e.field || "field"} invalid`)
-              .slice(0, 2)
-              .join("; ");
-          }
-        }
-        throw new Error(msg || `HTTP ${res.status}`);
-      }
-
+      await apiClient.post(
+        "/api/auth/sign-up",
+        { email: emailNorm, password: password1 },
+        { auth: false }
+      )
       navigate(`/auth/check-email?email=${encodeURIComponent(emailNorm)}`)
-
     } catch (err) {
       toast.error("Registration failed", {
         description: err?.message || "Unexpected error",

--- a/frontend/src/components/auth/SigninForm.jsx
+++ b/frontend/src/components/auth/SigninForm.jsx
@@ -13,42 +13,32 @@ import { useState } from "react"
 import { Loader2Icon, Eye, EyeOff, XCircle } from "lucide-react"
 import { toast } from "sonner"
 import { Toaster } from "@/components/ui/sonner"
+import { useNavigate, useLocation } from "react-router-dom"
+import { useAuth } from "@/context/AuthContext"
 
 export default function SigninForm() {
   const [email, setEmail] = useState("")
   const [password, setPassword] = useState("")
   const [loading, setLoading] = useState(false)
   const [showPassword, setShowPassword] = useState(false)
-  
 
+  const navigate = useNavigate()
+  const location = useLocation()
+  const { login } = useAuth()
 
   const handleSubmit = async (e) => {
     e.preventDefault()
     setLoading(true)
 
     try {
-      const res = await fetch("http://localhost:8080/api/auth/sign-in", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ email, password }),
-      })
+      await login(email.trim(), password)
 
-      if (!res.ok) {
-        console.log("❌ Login failed")
-        throw new Error("Invalid email or password")
-      }
-
-      const data = await res.json()
-      console.log("✅ Logged in:", data)
-
-      // тут можно сохранить токен в localStorage или context
-      localStorage.setItem("token", data.token)
-
+      // Redirect to the page the user was trying to reach, or /dashboard
+      const redirectTo = location.state?.from?.pathname || "/dashboard"
+      navigate(redirectTo, { replace: true })
     } catch (err) {
       toast.error("Login failed", {
-        description: err.message,
+        description: err?.message || "Invalid email or password",
         position: "top-center",
         icon: <XCircle className="h-5 w-5 text-red-500" />,
       })

--- a/frontend/src/components/auth/VerifyEmailForm.jsx
+++ b/frontend/src/components/auth/VerifyEmailForm.jsx
@@ -8,6 +8,7 @@ import { PartyPopper,Loader2Icon } from "lucide-react"
 import { Button } from '@/components/ui/button'
 
 import { toast } from "sonner"
+import { apiClient } from "@/lib/apiClient"
 
 export default function VerifyEmailForm() {
   const { search } = useLocation()
@@ -27,24 +28,12 @@ export default function VerifyEmailForm() {
         return
       }
       try {
-        let res = await fetch('http://localhost:8080/api/auth/verify', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ token }),
-        })
-
-        // запасной: если бэк ждёт query param
-        if (!res.ok && res.status === 400) {
-          res = await fetch(`http://localhost:8080/api/auth/verify?token=${encodeURIComponent(token)}`, { method: 'POST' })
-        }
-
-        const isJson = res.headers.get('content-type')?.includes('application/json')
-        const payload = isJson ? await res.json() : await res.text()
-
-        if (!res.ok) {
-          const msg = typeof payload === 'string' ? payload : payload?.detail || payload?.message || `HTTP ${res.status}`
-          throw new Error(msg)
-        }
+        // Backend expects token as a query param (POST /api/auth/verify?token=...)
+        await apiClient.post(
+          `/api/auth/verify?token=${encodeURIComponent(token)}`,
+          undefined,
+          { auth: false }
+        )
 
         setState({ loading: false, ok: true })
         toast.success("Email verified!", {

--- a/frontend/src/components/dashboard/base/app-sidebar.jsx
+++ b/frontend/src/components/dashboard/base/app-sidebar.jsx
@@ -16,13 +16,9 @@ import {
   SidebarMenu,
   SidebarMenuItem,
 } from "@/components/ui/sidebar"
+import { useAuth } from "@/context/AuthContext"
 
-const data = {
-  user: {
-    name: "shadcn",
-    email: "m@example.com",
-    avatar: "/avatars/shadcn.jpg",
-  },
+const navData = {
   navMain: [
     { title: "Overview", url: "/dashboard/overview", icon: IconDashboard },
     { title: "Analytics", url: "/dashboard/analytics", icon: IconChartBar },
@@ -38,18 +34,26 @@ const data = {
 }
 
 export function AppSidebar(props) {
+  const { user } = useAuth()
+
+  const displayUser = {
+    name: user?.email?.split("@")[0] || "User",
+    email: user?.email || "",
+    avatar: "",
+  }
+
   return (
     <Sidebar collapsible="offcanvas" {...props}>
       <SidebarHeader>
         <SidebarMenu>
           <SidebarMenuItem>
-            <NavUser user={data.user} />
+            <NavUser user={displayUser} />
           </SidebarMenuItem>
         </SidebarMenu>
       </SidebarHeader>
       <SidebarContent>
-        <NavMain items={data.navMain} />
-        <NavSecondary items={data.navSecondary} className="mt-auto" />
+        <NavMain items={navData.navMain} />
+        <NavSecondary items={navData.navSecondary} className="mt-auto" />
       </SidebarContent>
     </Sidebar>
   )

--- a/frontend/src/components/dashboard/base/nav-user.jsx
+++ b/frontend/src/components/dashboard/base/nav-user.jsx
@@ -28,11 +28,20 @@ import {
 } from "@/components/ui/sidebar"
 import { Moon, Sun } from "lucide-react"
 import { useTheme } from "@/components/theme-provider"
+import { useAuth } from "@/context/AuthContext"
+import { useNavigate } from "react-router-dom"
 
 export function NavUser({ user }) {
   const { isMobile } = useSidebar()
 
   const { theme, setTheme } = useTheme()
+  const { logout } = useAuth()
+  const navigate = useNavigate()
+
+  const handleLogout = () => {
+    logout()
+    navigate("/auth/sign-in", { replace: true })
+  }
 
   const toggleTheme = () => {
     if (theme === "light") setTheme("dark")
@@ -88,7 +97,7 @@ export function NavUser({ user }) {
               </DropdownMenuItem>
             </DropdownMenuGroup>
             <DropdownMenuSeparator />
-            <DropdownMenuItem>
+            <DropdownMenuItem onClick={handleLogout}>
               <IconLogout />
               Log out
             </DropdownMenuItem>

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,0 +1,90 @@
+import { createContext, useContext, useEffect, useState, useCallback } from "react"
+import {
+  apiClient,
+  setAuthTokens,
+  clearAuthTokens,
+  getAccessToken,
+  ApiError,
+} from "@/lib/apiClient"
+
+const AuthContext = createContext(null)
+
+export function AuthProvider({ children }) {
+  const [user, setUser] = useState(null)
+  const [loading, setLoading] = useState(true)
+
+  // On mount, try to restore session from a stored access token
+  useEffect(() => {
+    const token = getAccessToken()
+    if (!token) {
+      setLoading(false)
+      return
+    }
+
+    let cancelled = false
+    ;(async () => {
+      try {
+        const me = await apiClient.get("/api/users/me")
+        if (!cancelled) setUser(me)
+      } catch (e) {
+        // Token is invalid/expired — drop it
+        clearAuthTokens()
+        if (!cancelled) setUser(null)
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const login = useCallback(async (email, password) => {
+    const data = await apiClient.post(
+      "/api/auth/sign-in",
+      { email, password },
+      { auth: false }
+    )
+    setAuthTokens({
+      accessToken: data.accessToken,
+      refreshToken: data.refreshToken,
+    })
+
+    // Prefer the richer /me payload, fall back to what sign-in returned
+    try {
+      const me = await apiClient.get("/api/users/me")
+      setUser(me)
+    } catch {
+      setUser(data.user)
+    }
+
+    return data
+  }, [])
+
+  const logout = useCallback(() => {
+    clearAuthTokens()
+    setUser(null)
+  }, [])
+
+  const value = {
+    user,
+    loading,
+    isAuthenticated: !!user,
+    login,
+    logout,
+  }
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext)
+  if (!ctx) {
+    throw new Error("useAuth must be used within an AuthProvider")
+  }
+  return ctx
+}
+
+// Re-export for convenience
+export { ApiError }

--- a/frontend/src/lib/apiClient.js
+++ b/frontend/src/lib/apiClient.js
@@ -1,0 +1,99 @@
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:9000"
+
+export const TOKEN_STORAGE_KEY = "mmm_access_token"
+export const REFRESH_STORAGE_KEY = "mmm_refresh_token"
+
+export function getAccessToken() {
+  return localStorage.getItem(TOKEN_STORAGE_KEY)
+}
+
+export function setAuthTokens({ accessToken, refreshToken }) {
+  if (accessToken) localStorage.setItem(TOKEN_STORAGE_KEY, accessToken)
+  if (refreshToken) localStorage.setItem(REFRESH_STORAGE_KEY, refreshToken)
+}
+
+export function clearAuthTokens() {
+  localStorage.removeItem(TOKEN_STORAGE_KEY)
+  localStorage.removeItem(REFRESH_STORAGE_KEY)
+}
+
+/**
+ * Extract a human-readable error message from a backend error payload.
+ */
+function extractErrorMessage(payload, status) {
+  if (typeof payload === "string" && payload) return payload
+  if (payload && typeof payload === "object") {
+    if (payload.detail) return payload.detail
+    if (payload.message) return payload.message
+    if (Array.isArray(payload.errors) && payload.errors.length) {
+      return payload.errors
+        .map((e) => e.defaultMessage || e.message || `${e.field || "field"} invalid`)
+        .slice(0, 2)
+        .join("; ")
+    }
+  }
+  return `HTTP ${status}`
+}
+
+export class ApiError extends Error {
+  constructor(message, status, payload) {
+    super(message)
+    this.name = "ApiError"
+    this.status = status
+    this.payload = payload
+  }
+}
+
+/**
+ * Core request function. Automatically:
+ * - prefixes paths with VITE_API_BASE_URL
+ * - serializes body to JSON
+ * - attaches Authorization: Bearer if a token is stored (unless auth: false)
+ * - parses JSON response (or returns null for 204)
+ * - throws ApiError on non-2xx
+ */
+export async function request(path, { method = "GET", body, auth = true, headers = {} } = {}) {
+  const url = path.startsWith("http") ? path : `${API_BASE_URL}${path}`
+
+  const finalHeaders = {
+    Accept: "application/json",
+    ...headers,
+  }
+
+  if (body !== undefined) {
+    finalHeaders["Content-Type"] = "application/json"
+  }
+
+  if (auth) {
+    const token = getAccessToken()
+    if (token) {
+      finalHeaders["Authorization"] = `Bearer ${token}`
+    }
+  }
+
+  const res = await fetch(url, {
+    method,
+    headers: finalHeaders,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  })
+
+  if (res.status === 204) return null
+
+  const contentType = res.headers.get("content-type") || ""
+  const isJson = contentType.includes("application/json")
+  const payload = isJson ? await res.json().catch(() => null) : await res.text()
+
+  if (!res.ok) {
+    throw new ApiError(extractErrorMessage(payload, res.status), res.status, payload)
+  }
+
+  return payload
+}
+
+export const apiClient = {
+  get: (path, opts) => request(path, { ...opts, method: "GET" }),
+  post: (path, body, opts) => request(path, { ...opts, method: "POST", body }),
+  put: (path, body, opts) => request(path, { ...opts, method: "PUT", body }),
+  patch: (path, body, opts) => request(path, { ...opts, method: "PATCH", body }),
+  delete: (path, opts) => request(path, { ...opts, method: "DELETE" }),
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -4,12 +4,15 @@ import ReactDOM from "react-dom/client"
 import './index.css'
 import App from './App.jsx'
 import { ThemeProvider } from "@/components/theme-provider"
+import { AuthProvider } from "@/context/AuthContext"
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <StrictMode>
     <BrowserRouter>
       <ThemeProvider defaultTheme="system" storageKey="vite-ui-theme">
-        <App />
+        <AuthProvider>
+          <App />
+        </AuthProvider>
       </ThemeProvider>
     </BrowserRouter>
   </StrictMode>,


### PR DESCRIPTION
Adds the missing infrastructure to make the full registration → verification → sign-in → protected dashboard flow work against the backend.

New:
- src/lib/apiClient.js: centralized fetch wrapper with VITE_API_BASE_URL, automatic Bearer token injection, and unified error handling
- src/context/AuthContext.jsx: AuthProvider + useAuth hook; restores session on mount via GET /api/users/me
- src/components/ProtectedRoute.jsx: route guard that redirects unauthenticated users to /auth/sign-in
- frontend/.env: default VITE_API_BASE_URL=http://localhost:9000

Updated:
- main.jsx: wrap app in <AuthProvider>
- App.jsx: /dashboard is now behind <ProtectedRoute>
- SigninForm: uses login() from context; redirects to /dashboard on success; fixes bug where data.token was stored instead of data.accessToken
- SignUpForm / CheckEmailForm / VerifyEmailForm: migrated to apiClient, removed hardcoded http://localhost:8080 URLs
- app-sidebar.jsx: reads real user from auth context instead of hardcoded data
- nav-user.jsx: wires the Log out dropdown item to logout() + redirect