### PR TITLE
fix: use same-origin API calls in production, localhost only for dev

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,1 +1,4 @@
-VITE_API_BASE_URL=http://localhost:9000
+# In production: empty = same-origin (backend serves the SPA).
+# For local development, create .env.local with:
+#   VITE_API_BASE_URL=http://localhost:9000
+VITE_API_BASE_URL=

--- a/frontend/src/lib/apiClient.js
+++ b/frontend/src/lib/apiClient.js
@@ -1,4 +1,6 @@
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:9000"
+// In production the frontend is served by the backend (same origin),
+// so API_BASE_URL should be empty. For local dev, override via .env.local
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? ""
 
 export const TOKEN_STORAGE_KEY = "mmm_access_token"
 export const REFRESH_STORAGE_KEY = "mmm_refresh_token"


### PR DESCRIPTION
The backend serves the SPA, so in production API_BASE_URL should be empty (relative paths). Moved localhost:9000 default to .env.local (gitignored) and switched from || to ?? so empty string is respected.